### PR TITLE
Build: Adjust top level build system for simpler debugging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@
 /svg-2-android-vector/.gradle
 /svg-2-android-vector/build
 /svg-2-android-vector/local.properties
+
+bin/
+
+.project
+.settings/
+.classpath

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,6 @@
+include ":example-android-project"
+includeBuild("svg-2-android-vector") {
+    dependencySubstitution {
+        substitute module('com.quittle:svg-2-android-vector') with project(':')
+    }
+}

--- a/svg-2-android-vector/settings.gradle
+++ b/svg-2-android-vector/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "svg-2-android-vector"


### PR DESCRIPTION
Sets up a composite build. Doesn't work for me in Android Studio, however, due to an android sdk downloader error (see https://github.com/quittle/gradle-svg-2-android-vector/pull/85#discussion_r528347499 )