### PR TITLE
New resource generation using AndroidComponentsExtension.

### DIFF
--- a/example-android-project/build.gradle
+++ b/example-android-project/build.gradle
@@ -82,7 +82,6 @@ setupAndroidSdk {
 }
 
 dependencies {
-    androidTestImplementation "androidx.test.ext:junit:1.3.0"
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
 }

--- a/example-android-project/build.gradle
+++ b/example-android-project/build.gradle
@@ -33,6 +33,8 @@ android {
     defaultConfig {
         minSdk = 21
         targetSdk = 37
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     sourceSets {
         main {
@@ -77,4 +79,10 @@ svg2androidVector {
 
 setupAndroidSdk {
     licensesDirectory = file("licenses")
+}
+
+dependencies {
+    androidTestImplementation "androidx.test.ext:junit:1.3.0"
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test:rules:1.7.0'
 }

--- a/example-android-project/src/androidTest/java/ImportReferences.java
+++ b/example-android-project/src/androidTest/java/ImportReferences.java
@@ -2,5 +2,5 @@
  * Import the drawables to ensure they exist
  */
 
-import static com.example.R.drawable.android;
-import static com.example.R.drawable.test_1;
+import static com.example.test.R.drawable.android;
+import static com.example.R.drawable.test;

--- a/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorPlugin.java
+++ b/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorPlugin.java
@@ -1,20 +1,21 @@
 package com.quittle.svg2androidvector;
 
-import com.android.build.api.dsl.AndroidSourceDirectorySet;
-import com.android.build.api.dsl.AndroidSourceSet;
-import com.android.build.api.dsl.CommonExtension;
+import com.android.build.api.variant.AndroidComponentsExtension;
+import com.android.build.api.variant.Component;
+import com.android.build.api.variant.SourceDirectories;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.file.FileTree;
-import org.gradle.api.logging.Logger;
+import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.Directory;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.util.PatternFilterable;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Entry point for the project. This plugin will replace {@code res/raw&#42;/*.svg}
@@ -46,6 +47,10 @@ public class Svg2AndroidVectorPlugin implements Plugin<Project> {
             SVG_FILE_EXTENSION);
     private static final String CONVERSION_TASK_NAME_FORMAT = "ConvertSvgToXml-%s-%s";
 
+    // Official and immutable Android plugin IDs
+    private static final String ANDROID_APP_PLUGIN_ID = "com.android.application";
+    private static final String ANDROID_LIB_PLUGIN_ID = "com.android.library";
+
     /**
      * Default constructor.
      */
@@ -57,89 +62,16 @@ public class Svg2AndroidVectorPlugin implements Plugin<Project> {
         final Svg2AndroidVectorExtension extension = new Svg2AndroidVectorExtension();
         project.getExtensions().add(EXTENSION_NAME, extension);
 
-        // Starting in version 3.2.0 of the Android Gradle plugin, a double
-        // afterEvaluate is required to ensure the
-        // BuildableArtifactImpl is resolvable.
-        project.afterEvaluate(p1 -> {
-            p1.afterEvaluate(p2 -> {
-                onAfterEvaluate(p2, extension);
-            });
-        });
-    }
-
-    private static void onAfterEvaluate(final Project project, final Svg2AndroidVectorExtension extension) {
-        final Logger logger = project.getLogger();
-        final String displayName = project.getDisplayName();
-        // The base Android extension, where all resources can be found.
-        final CommonExtension androidExtension = project.getExtensions().findByType(CommonExtension.class);
-        if (androidExtension == null) {
-            // This might mean it was applied to a non-Android project, possibly just the
-            // root project.
-            logger.info(
-                    "{} had the Svg2AndroidVector plugin applied, " +
-                            "but the android plugin was not detected. Doing nothing",
-                    displayName);
-            return;
-        }
-        final TaskContainer taskContainer = project.getTasks();
-        final TaskProvider<Task> parentTaskProvider = taskContainer.register(CONVERSION_PARENT_TASK_NAME);
-        // An early Android task all the conversion tasks should be a dependency of
-        final TaskProvider<Task> preBuildTaskProvider = taskContainer.named(EARLY_ANDROID_TASK_NAME);
-
-        preBuildTaskProvider.configure( preBuildTask -> {
-            preBuildTask.dependsOn(parentTaskProvider);
-        });
-        // The folder to put the converted files
-        final File generatedResourceDir = project.getLayout().getBuildDirectory().file(BUILD_DIR_RESOURCE_NAME).get().getAsFile();
-        for (final AndroidSourceSet sourceSet : androidExtension.getSourceSets()) {
-            final String sourceSetName = sourceSet.getName(); // e.g. main, androidTest, debug, etc.
-            final AndroidSourceDirectorySet sourceDirectorySet = sourceSet.getRes();
-            getFileTreeFromSourceSet(sourceSet.getRes())
-                    .matching(filter -> filter.include(SVG_FILTER_PATTERN))
-                    .forEach(svgFile -> {
-                        // Create a task to build the Android vector equivalent file in an Android
-                        // resource
-                        // directory specifically for this source set
-                        final File newResourceDir = new File(generatedResourceDir, sourceSetName);
-                        final String suffix = getQualifierSuffix(svgFile);
-                        final String taskName = buildTaskName(sourceSetName + suffix, svgFile);
-                        final File xmlFile = Paths.get(newResourceDir.getAbsolutePath(),
-                            ANDROID_RESOURCES_DIR_NAME_DRAWABLE + suffix,
-                            svgFile.getName().replace(SVG_FILE_EXTENSION, XML_FILE_EXTENSION)).toFile();
-
-                        final TaskProvider<Svg2AndroidVectorTask> taskProvider = taskContainer.register(taskName,
-                            Svg2AndroidVectorTask.class, task -> {
-                                task.svg = svgFile;
-                                task.xml = xmlFile;
-                                task.failOnWarning = extension.getFailOnWarning();
-                            }
-                        );
-                        parentTaskProvider.configure( parentTask -> {
-                            parentTask.dependsOn(taskProvider);
-                        });
-
-                        // Add the new, generated resource directory for the source set
-                        sourceDirectorySet.getDirectories().add(newResourceDir.getAbsolutePath());
-                        // Remove the original resource from the resources. Two resources with the same
-                        // name but
-                        // different types may not share the same name.
-                        getSourceSetFilter(sourceDirectorySet).exclude(svgFile.getAbsolutePath());
-                    });
-        }
+        project.getPlugins().withId(ANDROID_APP_PLUGIN_ID, plugin ->
+            registerSvgFromVariantResources(project, extension)
+        );
+        project.getPlugins().withId(ANDROID_LIB_PLUGIN_ID, plugin ->
+            registerSvgFromVariantResources(project, extension)
+        );
     }
 
     private static String buildTaskName(final String sourceSetName, final File svgFile) {
         return String.format(CONVERSION_TASK_NAME_FORMAT, sourceSetName, svgFile.getName());
-    }
-
-    @SuppressWarnings("deprecation")
-    private static FileTree getFileTreeFromSourceSet(AndroidSourceDirectorySet sourceSet) {
-        return ((com.android.build.gradle.api.AndroidSourceDirectorySet) sourceSet).getSourceFiles();
-    }
-
-    @SuppressWarnings("deprecation")
-    private static PatternFilterable getSourceSetFilter(AndroidSourceDirectorySet sourceSet) {
-        return ((com.android.build.gradle.api.AndroidSourceDirectorySet) sourceSet).getFilter();
     }
 
     /**
@@ -157,5 +89,86 @@ public class Svg2AndroidVectorPlugin implements Plugin<Project> {
         }
         // If there is no hyphen (just the "raw" folder), there is no qualifier.
         return "";
+    }
+
+    private static void registerSvgFromVariantResources(final Project project, final Svg2AndroidVectorExtension extension) {
+        AndroidComponentsExtension<?, ?, ?> androidComponents =
+                project.getExtensions().getByType(AndroidComponentsExtension.class);
+
+        androidComponents.onVariants(androidComponents.selector().all(), variant -> {
+            // 1. Processing the resources of the main application
+            registerSvgTaskForComponent(project, extension, variant);
+
+            // 2. Explicitly iterate over nested test components (androidTest)
+            for (Component nestedComponent : variant.getNestedComponents()) {
+                // We check that this is indeed an instrumented testing component
+                if (nestedComponent.getName().endsWith("AndroidTest")) {
+                    registerSvgTaskForComponent(project, extension, nestedComponent);
+                }
+            }
+        });
+    }
+
+    private static void registerSvgTaskForComponent(final Project project,
+                                                    final Svg2AndroidVectorExtension extension,
+                                                    final Component component) {
+
+        final SourceDirectories.Layered variantRes = component.getSources().getRes();
+
+        if (variantRes == null) {
+            return;
+        }
+
+        final TaskContainer taskContainer = project.getTasks();
+        final Provider<List<Collection<Directory>>> resProvider = variantRes.getAll();
+        final List<Collection<Directory>> resourceCollections = resProvider.get();
+        final String componentName = component.getName();
+
+        for (Collection<Directory> setOfDirs : resourceCollections) {
+            for (Directory directory : setOfDirs) {
+                File resDir = directory.getAsFile();
+
+                if (resDir.exists()) {
+
+                    ConfigurableFileTree svgTree = project.fileTree(resDir);
+                    svgTree.include(SVG_FILTER_PATTERN);
+
+                    svgTree.forEach(svgFile -> {
+                        final String suffix = getQualifierSuffix(svgFile);
+                        final String taskName = buildTaskName(componentName + suffix, svgFile);
+
+                        // Take first file when resources have the same filename in different flavours and in the main
+                        if (taskContainer.findByName(taskName) == null) {
+                            // create relative path to new generated resource directory
+                            final String relativeOutPath = Paths.get(
+                                BUILD_DIR_RESOURCE_NAME,
+                                componentName).toString();
+                            // create relative path to drawable directory with localization suffix
+                            final String drawableRelativeOutPath = Paths.get(
+                                relativeOutPath,
+                                ANDROID_RESOURCES_DIR_NAME_DRAWABLE + suffix).toString();
+
+                            final TaskProvider<Svg2AndroidVectorTask> taskProvider = taskContainer.register(taskName,
+                                Svg2AndroidVectorTask.class, task -> {
+                                    task.svg = svgFile;
+                                    task.failOnWarning = extension.getFailOnWarning();
+                                    // Absolute path must be created inside the task.
+                                    // Ouside getBuildDirectory returns path to working directory
+                                    // of the currently running process - that is the Gradle daemon.
+                                    task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir(relativeOutPath));
+                                    task.xml = new File(project.getLayout().getBuildDirectory().dir(drawableRelativeOutPath).get().toString(),
+                                        svgFile.getName().replace(SVG_FILE_EXTENSION, XML_FILE_EXTENSION));
+                                }
+                            );
+
+                            variantRes.addGeneratedSourceDirectory(
+                                taskProvider,
+                                Svg2AndroidVectorTask::getOutputDirectory
+                            );
+                        }
+                    });
+                }
+            }
+        }
     }
 }

--- a/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorPlugin.java
+++ b/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorPlugin.java
@@ -101,10 +101,7 @@ public class Svg2AndroidVectorPlugin implements Plugin<Project> {
 
             // 2. Explicitly iterate over nested test components (androidTest)
             for (Component nestedComponent : variant.getNestedComponents()) {
-                // We check that this is indeed an instrumented testing component
-                if (nestedComponent.getName().endsWith("AndroidTest")) {
-                    registerSvgTaskForComponent(project, extension, nestedComponent);
-                }
+                registerSvgTaskForComponent(project, extension, nestedComponent);
             }
         });
     }
@@ -129,7 +126,6 @@ public class Svg2AndroidVectorPlugin implements Plugin<Project> {
                 File resDir = directory.getAsFile();
 
                 if (resDir.exists()) {
-
                     ConfigurableFileTree svgTree = project.fileTree(resDir);
                     svgTree.include(SVG_FILTER_PATTERN);
 

--- a/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorTask.java
+++ b/svg-2-android-vector/src/main/java/com/quittle/svg2androidvector/Svg2AndroidVectorTask.java
@@ -10,8 +10,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
@@ -25,7 +27,7 @@ import org.gradle.work.DisableCachingByDefault;
  */
 @SuppressWarnings("PMD.BeanMembersShouldSerialize")
 @DisableCachingByDefault(because = "This task transforms SVG to Android Vector which is fast enough")
-public class Svg2AndroidVectorTask extends DefaultTask {
+public abstract class Svg2AndroidVectorTask extends DefaultTask {
     /**
      * Default constructor.
      */
@@ -62,6 +64,13 @@ public class Svg2AndroidVectorTask extends DefaultTask {
     public boolean getFailOnWarning() {
         return failOnWarning;
     }
+
+    /**
+     * Output directory for lazy linking in addGeneratedSourceDirectory().
+     * @return generated directory for task converting svg to xml.
+     */
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDirectory();
 
     File svg = null;
     File xml = null;

--- a/validate_plugin
+++ b/validate_plugin
@@ -83,13 +83,13 @@ INTERNAL_FILE_HASH='5ae805f046c1c0288860f9c822fbc2e9cc51844238d39b1bfaf71368450d
 PROD_FILE_HASH='5ae805f046c1c0288860f9c822fbc2e9cc51844238d39b1bfaf71368450d8513'
 
 # Default build
-./gradlew -p example-android-project assemble
+./gradlew -p example-android-project assemble connectedAndroidTest
 assert_file_exists "$VECTOR_RESOURCES_DIR"
-assert_file_hash "${VECTOR_RESOURCES_DIR}/main/drawable/test.xml" "${TEST_FILE_HASH}"
-assert_file_hash "${VECTOR_RESOURCES_DIR}/androidTest/drawable/android.xml" "${ANDROID_FILE_HASH}"
-assert_file_hash "${VECTOR_RESOURCES_DIR}/main/drawable-en/checklist.xml" "${CHECKLISK_FILE_HASH}"
-assert_file_hash "${VECTOR_RESOURCES_DIR}/internal/drawable/take_a_bath.xml" "${INTERNAL_FILE_HASH}"
-assert_file_hash "${VECTOR_RESOURCES_DIR}/prod/drawable/take_a_bath.xml" "${PROD_FILE_HASH}"
+assert_file_hash "${VECTOR_RESOURCES_DIR}/internalNormalRelease/drawable/test.xml" "${TEST_FILE_HASH}"
+assert_file_hash "${VECTOR_RESOURCES_DIR}/internalNormalDebugAndroidTest/drawable/android.xml" "${ANDROID_FILE_HASH}"
+assert_file_hash "${VECTOR_RESOURCES_DIR}/prodNormalRelease/drawable-en/checklist.xml" "${CHECKLISK_FILE_HASH}"
+assert_file_hash "${VECTOR_RESOURCES_DIR}/internalNormalRelease/drawable/take_a_bath.xml" "${INTERNAL_FILE_HASH}"
+assert_file_hash "${VECTOR_RESOURCES_DIR}/prodNormalRelease/drawable/take_a_bath.xml" "${PROD_FILE_HASH}"
 
 build_with_failure true ''
 

--- a/validate_plugin
+++ b/validate_plugin
@@ -83,7 +83,7 @@ INTERNAL_FILE_HASH='5ae805f046c1c0288860f9c822fbc2e9cc51844238d39b1bfaf71368450d
 PROD_FILE_HASH='5ae805f046c1c0288860f9c822fbc2e9cc51844238d39b1bfaf71368450d8513'
 
 # Default build
-./gradlew -p example-android-project assemble connectedAndroidTest
+./gradlew -p example-android-project assemble assembleAndroidTest
 assert_file_exists "$VECTOR_RESOURCES_DIR"
 assert_file_hash "${VECTOR_RESOURCES_DIR}/internalNormalRelease/drawable/test.xml" "${TEST_FILE_HASH}"
 assert_file_hash "${VECTOR_RESOURCES_DIR}/internalNormalDebugAndroidTest/drawable/android.xml" "${ANDROID_FILE_HASH}"


### PR DESCRIPTION
Change with completely new way to create tasks using AndroidComponentsExtension and with lazy linking in addGeneratedSourceDirectory. It is modern way for resource generation.

Why do we need it?
- In older versions of AGP, developers manually appended file paths to sourceSets. This approach regularly broke builds because Gradle had no built-in knowledge that it needed to run your custom generation task before compiling the code.addGeneratedSourceDirectory solves this by explicitly linking a producer task (the one creating the files) to a consumer task (the AGP task compiling or packaging them). This guarantees:
- Correct Task Ordering: Gradle ensures your generation task completes before AGP processes resources.
Incremental Builds: If your source files (like SVGs) don't change, Gradle skips your task (UP-TO-DATE), speeding up build times.
- IDE Integration: Android Studio recognizes these paths, meaning your generated code or resources won't show up as unresolved "red" errors.

It is solves problem in my project on merging resources with styles using generated xml.

Added changes for androidTest.